### PR TITLE
AWS Runis sailing due to log group

### DIFF
--- a/cicd/task-definition.json
+++ b/cicd/task-definition.json
@@ -18,15 +18,7 @@
             "command": ["/startup.sh"],
             "environment": [],
             "mountPoints": [],
-            "volumesFrom": [],
-            "logConfiguration": {
-                "logDriver": "awslogs",
-                "options": {
-                    "awslogs-group": "/ecs/seventeen-task-definition",
-                    "awslogs-region": "us-east-1",
-                    "awslogs-stream-prefix": "ecs"
-                }
-            }
+            "volumesFrom": []
         }
     ],
     "family": "seventeen-task-definition",

--- a/cicd/terraform/ecs_service.tf
+++ b/cicd/terraform/ecs_service.tf
@@ -8,5 +8,5 @@ resource "aws_ecs_service" "seventeen" {
     security_groups = ["sg-076e450d6b2cafad9"]
     assign_public_ip = true
   }
-
+  desired_count = 1
 }


### PR DESCRIPTION
- Remove log group and see what happens